### PR TITLE
Fix duplicate margin in label styles

### DIFF
--- a/src/styles/formStyles.js
+++ b/src/styles/formStyles.js
@@ -11,10 +11,8 @@ export const inputStyle = {
 };
 
 export const labelStyle = {
-  marginBottom: '0.5rem', // 👈 dodane
-
+  marginBottom: '0.5rem',
   fontSize: '14px',
-  marginBottom: '0.25rem',
   color: '#FAFAFA',
 };
 


### PR DESCRIPTION
## Summary
- clean up `labelStyle` by removing duplicate `marginBottom` and outdated comment

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c0afbac8323a924900f14d09229