### PR TITLE
Implement CV reset function

### DIFF
--- a/src/store/cvStore.js
+++ b/src/store/cvStore.js
@@ -5,7 +5,7 @@ import { persist } from 'zustand/middleware';
 
 let store;
 
-const storeConfig = (set) => ({
+const getInitialState = () => ({
   personalData: {
     fullName: '',
     headline: '',
@@ -23,6 +23,11 @@ const storeConfig = (set) => ({
   skills: [],
   projects: [],
   languages: [],
+  hasHydrated: false,
+});
+
+const storeConfig = (set) => ({
+  ...getInitialState(),
 
   setPersonalData: (data) => set({ personalData: data }),
   setProfile: (data) => set({ profile: data }),
@@ -33,8 +38,8 @@ const storeConfig = (set) => ({
   setProjects: (data) => set({ projects: data }),
   setLanguages: (data) => set({ languages: data }),
 
-  hasHydrated: false,
   setHasHydrated: () => set({ hasHydrated: true }),
+  resetCV: () => set(getInitialState()),
 });
 
 // twórz store tylko raz (w przeglądarce)


### PR DESCRIPTION
## Summary
- implement `resetCV` in `cvStore`
- expose `resetCV` via the store for `ResetCVButton`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c18e6cc8323a1d9795031118f6d