### PR TITLE
Add vitest setup and store reset test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "html2pdf.js": "^0.10.3",
@@ -24,6 +25,7 @@
     "eslint-config-next": "15.2.5",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.6",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/store/cvStore.js
+++ b/src/store/cvStore.js
@@ -33,6 +33,27 @@ const storeConfig = (set) => ({
   setProjects: (data) => set({ projects: data }),
   setLanguages: (data) => set({ languages: data }),
 
+  resetCV: () =>
+    set({
+      personalData: {
+        fullName: '',
+        headline: '',
+        email: '',
+        phone: '',
+        location: '',
+        portfolio: '',
+        picture: '',
+        summary: '',
+      },
+      profile: {},
+      experience: [],
+      education: [],
+      certifications: [],
+      skills: [],
+      projects: [],
+      languages: [],
+    }),
+
   hasHydrated: false,
   setHasHydrated: () => set({ hasHydrated: true }),
 });

--- a/src/store/cvStore.test.js
+++ b/src/store/cvStore.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import store from './cvStore.js';
+
+const defaults = {
+  personalData: {
+    fullName: '',
+    headline: '',
+    email: '',
+    phone: '',
+    location: '',
+    portfolio: '',
+    picture: '',
+    summary: '',
+  },
+  profile: {},
+  experience: [],
+  education: [],
+  certifications: [],
+  skills: [],
+  projects: [],
+  languages: [],
+};
+
+describe('cvStore resetCV', () => {
+  it('resets all fields to defaults', () => {
+    const {
+      setPersonalData,
+      setProfile,
+      setExperience,
+      resetCV,
+    } = store.getState();
+
+    setPersonalData({
+      fullName: 'John',
+      headline: 'Developer',
+      email: 'john@example.com',
+      phone: '123',
+      location: 'Somewhere',
+      portfolio: 'john.com',
+      picture: 'pic',
+      summary: 'bio',
+    });
+    setProfile({ foo: 'bar' });
+    setExperience([{ company: 'X' }]);
+
+    resetCV();
+
+    const state = store.getState();
+    expect(state.personalData).toEqual(defaults.personalData);
+    expect(state.profile).toEqual(defaults.profile);
+    expect(state.experience).toEqual(defaults.experience);
+    expect(state.education).toEqual(defaults.education);
+    expect(state.certifications).toEqual(defaults.certifications);
+    expect(state.skills).toEqual(defaults.skills);
+    expect(state.projects).toEqual(defaults.projects);
+    expect(state.languages).toEqual(defaults.languages);
+  });
+});


### PR DESCRIPTION
## Summary
- add `resetCV` function to store
- introduce `vitest` test runner
- add test verifying `resetCV`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c3223708323b5776e1ec1677b2b