### PR TITLE
Fix preview fields

### DIFF
--- a/src/components/CVPreview.jsx
+++ b/src/components/CVPreview.jsx
@@ -134,7 +134,7 @@ export default function CVPreview() {
                   <strong>{edu.degree}</strong> – {edu.field} ({edu.dateRange})
                   <br />
                   {edu.school} ({edu.mode})<br />
-                  {edu.summary && <p>{edu.summary}</p>}
+                  {edu.description && <p>{edu.description}</p>}
                 </div>
               ))}
             </>
@@ -152,14 +152,10 @@ export default function CVPreview() {
                     marginBottom: '1rem',
                   }}
                 >
-                  <strong>{proj.name}</strong> ({proj.date})<br />
+                  <strong>{proj.name}</strong> ({proj.dateRange})<br />
                   {proj.description}
                   <br />
-                  <em>{proj.techStack}</em>
-                  <br />
                   {proj.link && <a href={proj.link}>{proj.link}</a>}
-                  <br />
-                  {proj.summary && <p>{proj.summary}</p>}
                 </div>
               ))}
             </>

--- a/src/store/cvStore.js
+++ b/src/store/cvStore.js
@@ -5,7 +5,7 @@ import { persist } from 'zustand/middleware';
 
 let store;
 
-const storeConfig = (set) => ({
+const defaultState = {
   personalData: {
     fullName: '',
     headline: '',
@@ -23,6 +23,10 @@ const storeConfig = (set) => ({
   skills: [],
   projects: [],
   languages: [],
+};
+
+const storeConfig = (set) => ({
+  ...defaultState,
 
   setPersonalData: (data) => set({ personalData: data }),
   setProfile: (data) => set({ profile: data }),
@@ -32,6 +36,8 @@ const storeConfig = (set) => ({
   setSkills: (data) => set({ skills: data }),
   setProjects: (data) => set({ projects: data }),
   setLanguages: (data) => set({ languages: data }),
+
+  resetCV: () => set(defaultState),
 
   hasHydrated: false,
   setHasHydrated: () => set({ hasHydrated: true }),

--- a/src/styles/formStyles.js
+++ b/src/styles/formStyles.js
@@ -11,8 +11,6 @@ export const inputStyle = {
 };
 
 export const labelStyle = {
-  marginBottom: '0.5rem', // 👈 dodane
-
   fontSize: '14px',
   marginBottom: '0.25rem',
   color: '#FAFAFA',


### PR DESCRIPTION
## Summary
- align CV preview with latest education and project form fields
- ensure default state and reset function remain available

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684066227b1083238cd758bebeaa9021