### PR TITLE
Add appearance customization options

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -17,6 +17,7 @@ import LanguagesPopup from '../components/LanguagesPopup';
 import LanguagesList from '../components/LanguagesList';
 import CertificationPopup from '../components/CertificationPopup';
 import CertificationsList from '../components/CertificationsList';
+import AppearanceForm from '../components/AppearanceForm';
 import dynamic from 'next/dynamic';
 import ResetCVButton from '../components/ResetCVButton';
 import Section from '../components/Section';
@@ -29,6 +30,7 @@ import {
   Award,
   Globe,
   Brain,
+  Palette,
   Maximize2,
   Minimize2,
 } from 'lucide-react';
@@ -155,6 +157,9 @@ export default function Home() {
           <Section title="Certyfikaty" icon={Award}>
             <CertificationPopup ref={certificationPopupRef} />
             <CertificationsList popupRef={certificationPopupRef} />
+          </Section>
+          <Section title="Wygląd" icon={Palette}>
+            <AppearanceForm />
           </Section>
         </div>
 

--- a/src/components/AppearanceForm.jsx
+++ b/src/components/AppearanceForm.jsx
@@ -1,0 +1,116 @@
+'use client';
+import { useState, useEffect } from 'react';
+import useCVStore from '../store/cvStore';
+import { inputStyle, labelStyle, formStyle } from '../styles/formStyles';
+
+const COLORS = [
+  '#ef4444', '#f97316', '#f59e0b', '#eab308',
+  '#84cc16', '#22c55e', '#14b8a6', '#06b6d4',
+  '#0ea5e9', '#3b82f6', '#6366f1', '#8b5cf6',
+  '#a855f7', '#d946ef', '#ec4899', '#f43f5e',
+];
+
+const FONTS = [
+  'Arial',
+  'Cambria',
+  'Garamond',
+  'IBM Plex Sans',
+  'IBM Plex Serif',
+  'Lato',
+  'Lora',
+  'Merriweather',
+  'Open Sans',
+  'Playfair Display',
+  'PT Sans',
+  'PT Serif',
+  'Roboto Condensed',
+  'Times New Roman',
+];
+
+export default function AppearanceForm() {
+  const appearance = useCVStore((s) => s.appearance);
+  const setAppearance = useCVStore((s) => s.setAppearance);
+  const hasHydrated = useCVStore((s) => s.hasHydrated);
+
+  const [formData, setFormData] = useState(appearance);
+
+  useEffect(() => {
+    if (hasHydrated) {
+      setFormData(appearance);
+    }
+  }, [hasHydrated]);
+
+  useEffect(() => {
+    if (hasHydrated) {
+      setAppearance(formData);
+    }
+  }, [formData, setAppearance, hasHydrated]);
+
+  const handleColorChange = (color) => {
+    setFormData((prev) => ({ ...prev, color }));
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: name === 'fontSize' ? parseInt(value, 10) : parseFloat(value) || value }));
+  };
+
+  if (!hasHydrated) return null;
+
+  return (
+    <form style={formStyle}>
+      <div>
+        <label style={labelStyle}>Akcent kolorystyczny</label>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
+          {COLORS.map((c) => (
+            <div
+              key={c}
+              onClick={() => handleColorChange(c)}
+              style={{
+                width: '24px',
+                height: '24px',
+                borderRadius: '4px',
+                backgroundColor: c,
+                border: c === formData.color ? '2px solid #fff' : '1px solid #333',
+                cursor: 'pointer',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+      <div>
+        <label style={labelStyle}>Font</label>
+        <select name="font" value={formData.font} onChange={handleChange} style={inputStyle}>
+          {FONTS.map((f) => (
+            <option key={f} value={f}>{f}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label style={labelStyle}>Rozmiar czcionki: {formData.fontSize}px</label>
+        <input
+          type="range"
+          name="fontSize"
+          min="12"
+          max="24"
+          value={formData.fontSize}
+          onChange={handleChange}
+          style={{ width: '100%' }}
+        />
+      </div>
+      <div>
+        <label style={labelStyle}>Wysokość linii: {formData.lineHeight.toFixed(1)}</label>
+        <input
+          type="range"
+          name="lineHeight"
+          min="1"
+          max="2"
+          step="0.1"
+          value={formData.lineHeight}
+          onChange={handleChange}
+          style={{ width: '100%' }}
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/components/CVPreview.jsx
+++ b/src/components/CVPreview.jsx
@@ -1,12 +1,14 @@
 'use client';
 import useCVStore from '../store/cvStore';
 
-const sectionHeadingStyle = {
-  fontSize: '18px',
-  marginBottom: '0.25rem',
-  borderBottom: '2px solid red',
-  paddingBottom: '0.25rem',
-};
+function getSectionHeadingStyle(color) {
+  return {
+    fontSize: '18px',
+    marginBottom: '0.25rem',
+    borderBottom: `2px solid ${color}`,
+    paddingBottom: '0.25rem',
+  };
+}
 
 export default function CVPreview() {
   const {
@@ -18,13 +20,18 @@ export default function CVPreview() {
     skills,
     languages,
     certifications,
+    appearance,
   } = useCVStore();
+
+  const sectionHeadingStyle = getSectionHeadingStyle(appearance.color);
 
   return (
     <div
       id="cv-preview"
       style={{
-        fontFamily: 'sans-serif',
+        fontFamily: appearance.font,
+        fontSize: `${appearance.fontSize}px`,
+        lineHeight: appearance.lineHeight,
         color: '#000',
         WebkitPrintColorAdjust: 'exact',
         printColorAdjust: 'exact',
@@ -198,7 +205,7 @@ export default function CVPreview() {
                   <li key={i}>
                     <strong>{s.name}</strong>
                     <br />
-                    {renderLevelDots(s.level)}
+                    {renderLevelDots(s.level, appearance.color)}
                   </li>
                 ))}
               </ul>
@@ -213,7 +220,7 @@ export default function CVPreview() {
                   <li key={i}>
                     <strong>{lang.name}</strong>
                     <br />
-                    {renderLevelDots(lang.level)}
+                    {renderLevelDots(lang.level, appearance.color)}
                   </li>
                 ))}
               </ul>
@@ -252,7 +259,7 @@ export default function CVPreview() {
   );
 }
 
-function renderLevelDots(level) {
+function renderLevelDots(level, color = 'red') {
   const total = 5;
   return Array.from({ length: total }, (_, i) => (
     <span
@@ -263,8 +270,8 @@ function renderLevelDots(level) {
         height: '12px',
         borderRadius: '50%',
         marginRight: '4px',
-        backgroundColor: i < level ? 'red' : '#fff',
-        border: '1px solid red',
+        backgroundColor: i < level ? color : '#fff',
+        border: `1px solid ${color}`,
       }}
     />
   ));

--- a/src/store/cvStore.js
+++ b/src/store/cvStore.js
@@ -23,6 +23,12 @@ const getInitialState = () => ({
   skills: [],
   projects: [],
   languages: [],
+  appearance: {
+    color: '#dc2626', // red-600
+    font: 'Arial',
+    fontSize: 14,
+    lineHeight: 1.4,
+  },
   hasHydrated: false,
 });
 
@@ -37,6 +43,7 @@ const storeConfig = (set) => ({
   setSkills: (data) => set({ skills: data }),
   setProjects: (data) => set({ projects: data }),
   setLanguages: (data) => set({ languages: data }),
+  setAppearance: (data) => set({ appearance: data }),
 
   setHasHydrated: () => set({ hasHydrated: true }),
   resetCV: () => set(getInitialState()),


### PR DESCRIPTION
## Summary
- store appearance settings including color, font, size and line height
- create `AppearanceForm` for picking colors, fonts and typographic settings
- apply appearance settings in `CVPreview`
- include new section in the main page to edit appearance

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684072e373348323b3ffa3d4d7be1245