### PR TITLE
Add Google login with per-account storage

### DIFF
--- a/src/app/builder/page.js
+++ b/src/app/builder/page.js
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import PersonalDataForm from '../../components/PersonalDataForm';
+import CVPreview from '../../components/CVPreview';
+import ExperiencePopup from '../../components/ExperiencePopup';
+import ExperienceList from '../../components/ExperienceList';
+import EducationPopup from '../../components/EducationPopup';
+import EducationList from '../../components/EducationList';
+import ProfilePopup from '../../components/ProfilePopup';
+import ProfilesList from '../../components/ProfilesList';
+import ProjectsPopup from '../../components/ProjectsPopup';
+import ProjectsList from '../../components/ProjectsList';
+import SkillsPopup from '../../components/SkillsPopup';
+import SkillsList from '../../components/SkillsList';
+import LanguagesPopup from '../../components/LanguagesPopup';
+import LanguagesList from '../../components/LanguagesList';
+import CertificationPopup from '../../components/CertificationPopup';
+import CertificationsList from '../../components/CertificationsList';
+import AppearanceForm from '../../components/AppearanceForm';
+import dynamic from 'next/dynamic';
+import ResetCVButton from '../../components/ResetCVButton';
+import Section from '../../components/Section';
+import {
+  User,
+  Briefcase,
+  Book,
+  Code,
+  Languages,
+  Award,
+  Globe,
+  Brain,
+  Palette,
+  Maximize2,
+  Minimize2,
+} from 'lucide-react';
+
+const PdfDownloadButton = dynamic(
+  () => import('../../components/PdfDownloadButton'),
+  {
+    ssr: false,
+  }
+);
+
+export default function Home() {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState('form');
+  const [fullscreenPreview, setFullscreenPreview] = useState(false);
+
+  useEffect(() => {
+    const user = localStorage.getItem('cv-user');
+    if (!user) {
+      router.replace('/');
+    }
+  }, [router]);
+
+  const handleLogout = () => {
+    localStorage.removeItem('cv-user');
+    localStorage.removeItem('cv-builder-email');
+    router.replace('/');
+  };
+
+  const toggleFullscreen = () => {
+    setFullscreenPreview((prev) => !prev);
+    setActiveTab('preview');
+  };
+
+  const experiencePopupRef = useRef();
+  const educationPopupRef = useRef();
+  const projectsPopupRef = useRef();
+  const skillsPopupRef = useRef();
+  const languagesPopupRef = useRef();
+  const certificationPopupRef = useRef();
+  const profilePopupRef = useRef();
+
+  return (
+    <main
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        fontFamily: 'IBM Plex Sans, sans-serif',
+        backgroundColor: '#09090b',
+        color: '#FAFAFA',
+      }}
+    >
+      {/* Topbar */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 1000,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: '#09090b',
+          padding: '1rem 2rem',
+          borderBottom: '1px solid #222',
+        }}
+      >
+        <h1 style={{ fontSize: '20px', margin: 0 }}>CV Builder</h1>
+        <div style={{ display: 'flex', gap: '1.25rem' }}>
+          <ResetCVButton />
+          <PdfDownloadButton />
+          <button
+            onClick={toggleFullscreen}
+            title="Przełącz tryb pełnoekranowy"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: '#FAFAFA',
+              cursor: 'pointer',
+              padding: '0.5rem',
+            }}
+          >
+            {fullscreenPreview ? (
+              <Minimize2 size={20} />
+            ) : (
+              <Maximize2 size={20} />
+            )}
+          </button>
+          <button
+            onClick={handleLogout}
+            style={{
+              background: 'transparent',
+              border: '1px solid #444',
+              color: '#FAFAFA',
+              cursor: 'pointer',
+              padding: '0.5rem 1rem',
+              borderRadius: '4px',
+            }}
+          >
+            Wyloguj
+          </button>
+        </div>
+      </div>
+
+      {/* Toggle buttons (mobile only) */}
+      <div className="cv-toggle-buttons">
+        <button
+          onClick={() => setActiveTab('form')}
+          className={activeTab === 'form' ? 'active' : ''}
+        >
+          Formularz
+        </button>
+        <button
+          onClick={() => setActiveTab('preview')}
+          className={activeTab === 'preview' ? 'active' : ''}
+        >
+          Podgląd
+        </button>
+      </div>
+
+      {/* Layout */}
+      <div className={`cv-layout ${fullscreenPreview ? 'fullscreen' : ''}`}>
+        <div className={`cv-left ${activeTab === 'form' ? 'show' : ''}`}>
+          <Section title="Dane osobowe" icon={User}>
+            <PersonalDataForm />
+          </Section>
+          <Section title="Profile" icon={Globe}>
+            <ProfilePopup ref={profilePopupRef} />
+            <ProfilesList popupRef={profilePopupRef} />
+          </Section>
+          <Section title="Doświadczenie" icon={Briefcase}>
+            <ExperiencePopup ref={experiencePopupRef} />
+            <ExperienceList popupRef={experiencePopupRef} />
+          </Section>
+          <Section title="Edukacja" icon={Book}>
+            <EducationPopup ref={educationPopupRef} />
+            <EducationList popupRef={educationPopupRef} />
+          </Section>
+          <Section title="Projekty" icon={Code}>
+            <ProjectsPopup ref={projectsPopupRef} />
+            <ProjectsList popupRef={projectsPopupRef} />
+          </Section>
+          <Section title="Umiejętności" icon={Brain}>
+            <SkillsPopup ref={skillsPopupRef} />
+            <SkillsList popupRef={skillsPopupRef} />
+          </Section>
+          <Section title="Języki" icon={Languages}>
+            <LanguagesPopup ref={languagesPopupRef} />
+            <LanguagesList popupRef={languagesPopupRef} />
+          </Section>
+          <Section title="Certyfikaty" icon={Award}>
+            <CertificationPopup ref={certificationPopupRef} />
+            <CertificationsList popupRef={certificationPopupRef} />
+          </Section>
+          <Section title="Wygląd" icon={Palette}>
+            <AppearanceForm />
+          </Section>
+        </div>
+
+        <div className={`cv-right ${activeTab === 'preview' ? 'show' : ''}`}>
+          <div className="cv-preview-wrapper">
+            <CVPreview />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,173 +1,58 @@
 'use client';
 
-import { useState, useRef } from 'react';
-import PersonalDataForm from '../components/PersonalDataForm';
-import CVPreview from '../components/CVPreview';
-import ExperiencePopup from '../components/ExperiencePopup';
-import ExperienceList from '../components/ExperienceList';
-import EducationPopup from '../components/EducationPopup';
-import EducationList from '../components/EducationList';
-import ProfilePopup from '../components/ProfilePopup';
-import ProfilesList from '../components/ProfilesList';
-import ProjectsPopup from '../components/ProjectsPopup';
-import ProjectsList from '../components/ProjectsList';
-import SkillsPopup from '../components/SkillsPopup';
-import SkillsList from '../components/SkillsList';
-import LanguagesPopup from '../components/LanguagesPopup';
-import LanguagesList from '../components/LanguagesList';
-import CertificationPopup from '../components/CertificationPopup';
-import CertificationsList from '../components/CertificationsList';
-import AppearanceForm from '../components/AppearanceForm';
-import dynamic from 'next/dynamic';
-import ResetCVButton from '../components/ResetCVButton';
-import Section from '../components/Section';
-import {
-  User,
-  Briefcase,
-  Book,
-  Code,
-  Languages,
-  Award,
-  Globe,
-  Brain,
-  Palette,
-  Maximize2,
-  Minimize2,
-} from 'lucide-react';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
-const PdfDownloadButton = dynamic(
-  () => import('../components/PdfDownloadButton'),
-  {
-    ssr: false,
-  }
-);
+export default function SignIn() {
+  const router = useRouter();
 
-export default function Home() {
-  const [activeTab, setActiveTab] = useState('form');
-  const [fullscreenPreview, setFullscreenPreview] = useState(false);
+  useEffect(() => {
+    const user = localStorage.getItem('cv-user');
+    if (user) {
+      router.replace('/builder');
+    }
+  }, [router]);
 
-  const toggleFullscreen = () => {
-    setFullscreenPreview((prev) => !prev);
-    setActiveTab('preview');
-  };
+  useEffect(() => {
+    window.handleCredentialResponse = (response) => {
+      const decodeJwt = (token) => JSON.parse(atob(token.split('.')[1]));
+      const data = decodeJwt(response.credential);
+      localStorage.setItem('cv-user', JSON.stringify(data));
+      localStorage.setItem('cv-builder-email', data.email);
+      router.replace('/builder');
+    };
 
-  const experiencePopupRef = useRef();
-  const educationPopupRef = useRef();
-  const projectsPopupRef = useRef();
-  const skillsPopupRef = useRef();
-  const languagesPopupRef = useRef();
-  const certificationPopupRef = useRef();
-  const profilePopupRef = useRef();
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+      delete window.handleCredentialResponse;
+    };
+  }, [router]);
 
   return (
     <main
       style={{
         display: 'flex',
-        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
         height: '100vh',
-        fontFamily: 'IBM Plex Sans, sans-serif',
         backgroundColor: '#09090b',
         color: '#FAFAFA',
+        fontFamily: 'IBM Plex Sans, sans-serif',
       }}
     >
-      {/* Topbar */}
-      <div
-        style={{
-          position: 'sticky',
-          top: 0,
-          zIndex: 1000,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          backgroundColor: '#09090b',
-          padding: '1rem 2rem',
-          borderBottom: '1px solid #222',
-        }}
-      >
-        <h1 style={{ fontSize: '20px', margin: 0 }}>CV Builder</h1>
-        <div style={{ display: 'flex', gap: '1.25rem' }}>
-          <ResetCVButton />
-          <PdfDownloadButton />
-          <button
-            onClick={toggleFullscreen}
-            title="Przełącz tryb pełnoekranowy"
-            style={{
-              background: 'transparent',
-              border: 'none',
-              color: '#FAFAFA',
-              cursor: 'pointer',
-              padding: '0.5rem',
-            }}
-          >
-            {fullscreenPreview ? (
-              <Minimize2 size={20} />
-            ) : (
-              <Maximize2 size={20} />
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* Toggle buttons (mobile only) */}
-      <div className="cv-toggle-buttons">
-        <button
-          onClick={() => setActiveTab('form')}
-          className={activeTab === 'form' ? 'active' : ''}
-        >
-          Formularz
-        </button>
-        <button
-          onClick={() => setActiveTab('preview')}
-          className={activeTab === 'preview' ? 'active' : ''}
-        >
-          Podgląd
-        </button>
-      </div>
-
-      {/* Layout */}
-      <div className={`cv-layout ${fullscreenPreview ? 'fullscreen' : ''}`}>
-        <div className={`cv-left ${activeTab === 'form' ? 'show' : ''}`}>
-          <Section title="Dane osobowe" icon={User}>
-            <PersonalDataForm />
-          </Section>
-          <Section title="Profile" icon={Globe}>
-            <ProfilePopup ref={profilePopupRef} />
-            <ProfilesList popupRef={profilePopupRef} />
-          </Section>
-          <Section title="Doświadczenie" icon={Briefcase}>
-            <ExperiencePopup ref={experiencePopupRef} />
-            <ExperienceList popupRef={experiencePopupRef} />
-          </Section>
-          <Section title="Edukacja" icon={Book}>
-            <EducationPopup ref={educationPopupRef} />
-            <EducationList popupRef={educationPopupRef} />
-          </Section>
-          <Section title="Projekty" icon={Code}>
-            <ProjectsPopup ref={projectsPopupRef} />
-            <ProjectsList popupRef={projectsPopupRef} />
-          </Section>
-          <Section title="Umiejętności" icon={Brain}>
-            <SkillsPopup ref={skillsPopupRef} />
-            <SkillsList popupRef={skillsPopupRef} />
-          </Section>
-          <Section title="Języki" icon={Languages}>
-            <LanguagesPopup ref={languagesPopupRef} />
-            <LanguagesList popupRef={languagesPopupRef} />
-          </Section>
-          <Section title="Certyfikaty" icon={Award}>
-            <CertificationPopup ref={certificationPopupRef} />
-            <CertificationsList popupRef={certificationPopupRef} />
-          </Section>
-          <Section title="Wygląd" icon={Palette}>
-            <AppearanceForm />
-          </Section>
-        </div>
-
-        <div className={`cv-right ${activeTab === 'preview' ? 'show' : ''}`}>
-          <div className="cv-preview-wrapper">
-            <CVPreview />
-          </div>
-        </div>
+      <div>
+        <div
+          id="g_id_onload"
+          data-client_id="YOUR_GOOGLE_CLIENT_ID"
+          data-callback="handleCredentialResponse"
+        ></div>
+        <div className="g_id_signin" data-type="standard"></div>
       </div>
     </main>
   );

--- a/src/store/cvStore.js
+++ b/src/store/cvStore.js
@@ -50,11 +50,27 @@ const storeConfig = (set) => ({
 });
 
 // twórz store tylko raz (w przeglądarce)
+const dynamicLocalStorage = {
+  getItem: (name) => {
+    const email = window.localStorage.getItem('cv-builder-email') || 'anonymous';
+    return window.localStorage.getItem(`${name}-${email}`);
+  },
+  setItem: (name, value) => {
+    const email = window.localStorage.getItem('cv-builder-email') || 'anonymous';
+    window.localStorage.setItem(`${name}-${email}`, value);
+  },
+  removeItem: (name) => {
+    const email = window.localStorage.getItem('cv-builder-email') || 'anonymous';
+    window.localStorage.removeItem(`${name}-${email}`);
+  },
+};
+
 store =
   typeof window !== 'undefined'
     ? create(
         persist(storeConfig, {
           name: 'cv-builder-storage',
+          storage: dynamicLocalStorage,
           onRehydrateStorage: () => (state) => {
             state.setHasHydrated?.();
           },


### PR DESCRIPTION
## Summary
- route CV builder under `/builder`
- show new Google login page at root
- persist CV data under account-specific keys
- add logout option in builder view

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684076b224648323b94da4fc315be426